### PR TITLE
Server-Side Rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react-dom": "^15.3.2",
     "react-modal": "^1.5.2",
     "react-router": "^3.0.0",
+    "serializr": "^1.1.11",
     "spotify-web-api-node": "^2.3.6",
     "stats-webpack-plugin": "^0.6.0",
     "tinycolor2": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "run-client": "webpack-dev-server --config webpack/dev.js",
-    "run-server": "nodemon --watch 'src/**/*.ts' --ignore 'src/client/**/*.ts' --exec 'ts-node --fast' src/server/entry.ts",
-    "run-server-production": "ts-node --fast 'src/server/entry.ts'",
+    "run-server": "./scripts/server-watch",
+    "run-server-production": "echo TODO && exit 1",
     "build": "rm -rf build/ && webpack --config webpack/production.js && cp -r static/* build/",
     "deploy": "NODE_ENV=production npm run build && firebase deploy && heroku restart",
     "resetdb": "./scripts/resetdb",

--- a/scripts/server-watch
+++ b/scripts/server-watch
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require('path');
+const nodemon = require('nodemon');
+const webpack = require('webpack');
+const config = require('../webpack/server');
+
+function onBuild(err, stats) {
+  if (err) {
+    console.log('*** Webpack error:', err);
+  } else {
+    console.log(stats.toString());
+  }
+}
+
+nodemon({
+  script: path.join(__dirname, '../build/server/server.bundle.js'),
+
+  // we're just using nodemon to restart the process
+  ignore: ['*'],
+  watch: ['fake-folder/'],
+  ext: 'noop'
+});
+
+webpack(config).watch(100, (err, stats) => {
+  onBuild(err, stats);
+
+  if (!err) {
+    nodemon.restart();
+  }
+});
+
+// Without this, an error is raised when you ctrl-c after a watch-reload
+process.once('SIGINT', function(){
+  process.exit(0);
+});

--- a/src/client/components/AudioPlayer/Youtube.tsx
+++ b/src/client/components/AudioPlayer/Youtube.tsx
@@ -17,6 +17,11 @@ let ytPlayer: YT.Player | null = null;
 let ytPlayerReady = false;
 
 function setupYoutube() {
+  if (typeof YT === 'undefined') {
+    // hello server-side rendering~
+    return;
+  }
+
   if (!YT.Player && !(window as any).onYoutubeIframeAPIReady) {
     // wait for youtube to load and try again
     (window as any).onYoutubeIframeAPIReady = () => {

--- a/src/client/components/HomeScreen/LoggedInHome.tsx
+++ b/src/client/components/HomeScreen/LoggedInHome.tsx
@@ -18,9 +18,9 @@ interface Props {
   userStore: allStores.userStore,
 })) @observer
 class LoggedInHome extends React.Component<Props, {}> {
-  componentWillMount() {
-    this.props.feedStore!.reset();
-  }
+  // componentWillMount() {
+  //   this.props.feedStore!.reset();
+  // }
 
   renderNoItemsPlaceholder() {
     return (
@@ -31,7 +31,7 @@ class LoggedInHome extends React.Component<Props, {}> {
   }
 
   render() {
-    const {items, nextPageRequest, loadedFirstPage} = this.props.feedStore!.entryList;
+    console.log(this.props.feedStore!.entryList)
 
     return (
       <UserColorSchemeWrapper>

--- a/src/client/createApp.tsx
+++ b/src/client/createApp.tsx
@@ -44,7 +44,10 @@ export function createStores() {
 export function createRoutes() {
   return (
     <Route path="/" component={App}>
-      <IndexRoute component={HomeScreen} />
+      <IndexRoute component={HomeScreen}
+        fetchData={(stores, props) => {
+          return stores.feedStore.reset();
+        }} />
 
       <Route path="/about" component={AboutScreen} />
 

--- a/src/client/createApp.tsx
+++ b/src/client/createApp.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {render} from 'react-dom';
+import {Provider} from 'mobx-react';
+
+import {Router, Route, IndexRoute, browserHistory} from 'react-router';
+
+import App from './components/App';
+import HomeScreen from './components/HomeScreen';
+import ProfilePostPlaylist from './components/Profile/PostPlaylist';
+import ProfileLikedPlaylist from './components/Profile/LikedPlaylist';
+import ProfileFollowing from './components/Profile/Following';
+import ProfileFollowers from './components/Profile/Followers';
+import FindFriendsScreen from './components/FindFriendsScreen';
+import AboutScreen from './components/AboutScreen';
+import SettingsScreen from './components/SettingsScreen';
+import NotFoundScreen from './components/NotFoundScreen';
+
+import UserStore from './stores/UserStore';
+import AddSongStore from './stores/AddSongStore';
+import ProfileStore from './stores/ProfileStore';
+import PlaybackStore from './stores/PlaybackStore';
+import FeedStore from './stores/FeedStore';
+import FindFriendsStore from './stores/FindFriendsStore';
+import ColorSchemeStore from './stores/ColorSchemeStore';
+import UIStore from './stores/UIStore';
+
+type Stores = {[key: string]: object};
+
+export function createStores() {
+  const userStore = new UserStore();
+  const profileStore = new ProfileStore();
+  const playbackStore = new PlaybackStore();
+  const feedStore = new FeedStore();
+  const findFriendsStore = new FindFriendsStore();
+  const addSongStore = new AddSongStore(feedStore, profileStore);
+  const colorSchemeStore = new ColorSchemeStore();
+  const uiStore = new UIStore();
+
+  return {
+    userStore, addSongStore, profileStore, playbackStore, feedStore, findFriendsStore, colorSchemeStore, uiStore,
+  };
+}
+
+export function createRoutes() {
+  return (
+    <Route path="/" component={App}>
+      <IndexRoute component={HomeScreen} />
+
+      <Route path="/about" component={AboutScreen} />
+
+      <Route path="/users/:name" component={ProfilePostPlaylist} />
+      <Route path="/users/:name/liked" component={ProfileLikedPlaylist} />
+      <Route path="/users/:name/following" component={ProfileFollowing} />
+      <Route path="/users/:name/followers" component={ProfileFollowers} />
+
+      <Route path="/find-friends" component={FindFriendsScreen} />
+
+      <Route path="/settings" component={SettingsScreen} />
+
+      <Route path="*" component={NotFoundScreen} />
+    </Route>
+  );
+}
+
+export function createApp(stores: Stores) {
+  return (
+    <Provider {...stores}>
+      <Router history={browserHistory}>
+        {createRoutes()}
+      </Router>
+    </Provider>
+  );
+}

--- a/src/client/entry.tsx
+++ b/src/client/entry.tsx
@@ -5,64 +5,14 @@ import './registerSentry';
 
 import * as React from 'react';
 import {render} from 'react-dom';
-import {Provider} from 'mobx-react';
 
-import {Router, Route, IndexRoute, browserHistory} from 'react-router';
+import {createStores, createApp} from './createApp';
 
-import App from './components/App';
-import HomeScreen from './components/HomeScreen';
-import ProfilePostPlaylist from './components/Profile/PostPlaylist';
-import ProfileLikedPlaylist from './components/Profile/LikedPlaylist';
-import ProfileFollowing from './components/Profile/Following';
-import ProfileFollowers from './components/Profile/Followers';
-import FindFriendsScreen from './components/FindFriendsScreen';
-import AboutScreen from './components/AboutScreen';
-import SettingsScreen from './components/SettingsScreen';
-import NotFoundScreen from './components/NotFoundScreen';
-
-import UserStore from './stores/UserStore';
-import AddSongStore from './stores/AddSongStore';
-import ProfileStore from './stores/ProfileStore';
-import PlaybackStore from './stores/PlaybackStore';
-import FeedStore from './stores/FeedStore';
-import FindFriendsStore from './stores/FindFriendsStore';
-import ColorSchemeStore from './stores/ColorSchemeStore';
-import UIStore from './stores/UIStore';
-
-const userStore = new UserStore();
-const profileStore = new ProfileStore();
-const playbackStore = new PlaybackStore();
-const feedStore = new FeedStore();
-const findFriendsStore = new FindFriendsStore();
-const addSongStore = new AddSongStore(feedStore, profileStore);
-const colorSchemeStore = new ColorSchemeStore();
-const uiStore = new UIStore();
-
-const stores = {
-  userStore, addSongStore, profileStore, playbackStore, feedStore, findFriendsStore, colorSchemeStore, uiStore,
-};
-
+const stores = createStores();
+const pageData = (window as any).__PAGE_DATA__;
+if (pageData.currentUser) {
+  stores.userStore.loadUser(pageData.currentUser);
+}
 (window as any).stores = stores;
 
-render((
-  <Provider {...stores}>
-    <Router history={browserHistory}>
-      <Route path="/" component={App}>
-        <IndexRoute component={HomeScreen} />
-
-        <Route path="/about" component={AboutScreen} />
-
-        <Route path="/users/:name" component={ProfilePostPlaylist} />
-        <Route path="/users/:name/liked" component={ProfileLikedPlaylist} />
-        <Route path="/users/:name/following" component={ProfileFollowing} />
-        <Route path="/users/:name/followers" component={ProfileFollowers} />
-
-        <Route path="/find-friends" component={FindFriendsScreen} />
-
-        <Route path="/settings" component={SettingsScreen} />
-
-        <Route path="*" component={NotFoundScreen} />
-      </Route>
-    </Router>
-  </Provider>
-), document.querySelector('.react-root'));
+render(createApp(stores), document.querySelector('.react-root'));

--- a/src/client/stores/FeedStore.ts
+++ b/src/client/stores/FeedStore.ts
@@ -26,6 +26,6 @@ export default class FeedStore {
 
   @action reset() {
     this.entryList = new FeedPlaylistEntriesList();
-    this.entryList.getNextPage();
+    return this.entryList.getNextPage();
   }
 }

--- a/src/client/stores/UserStore.ts
+++ b/src/client/stores/UserStore.ts
@@ -13,23 +13,32 @@ export default class UserStore {
   @observable name: string | null = null;
   @observable userId: number | null = null;
   @observable following: PublicUser[] = [];
-  @observable colorScheme: ColorScheme | null = null;
+  @observable _colorScheme: ColorScheme | null = null;
 
-  constructor() {
-    const pageData = (window as any).__PAGE_DATA__ || {};
-    const user: CurrentUser | undefined = pageData.currentUser;
+  // TODO: Move me to entry.tsx
+  // constructor() {
+  //   const pageData = (window as any).__PAGE_DATA__ || {};
+  //   const user: CurrentUser | undefined = pageData.currentUser;
 
-    if (user) {
-      this.loggedIn = true;
-      this.name = user.name;
-      this.following = user.following;
-      this.userId = user.id;
-      this.colorScheme = user.colorScheme;
+  //   if (user) {
+  //     this.loadUser(user);
+  //   }
+  // }
+
+  loadUser(user: CurrentUser) {
+    this.loggedIn = true;
+    this.name = user.name;
+    this.following = user.following;
+    this.userId = user.id;
+    this._colorScheme = user.colorScheme;
+  }
+
+  get colorScheme() {
+    if (!this._colorScheme) {
+      return defaultColorScheme;
     }
 
-    if (!this.colorScheme) {
-      this.colorScheme = defaultColorScheme;
-    }
+    return this._colorScheme;
   }
 
   async signOut() {
@@ -52,6 +61,6 @@ export default class UserStore {
 
   @action async changeColorScheme(colorScheme: ColorScheme) {
     await changeColorScheme(colorScheme);
-    this.colorScheme = colorScheme;
+    this._colorScheme = colorScheme;
   }
 }

--- a/src/server/routes/pages.ts
+++ b/src/server/routes/pages.ts
@@ -1,70 +1,12 @@
 import {Router} from 'express';
-import axios from 'axios';
+
 import wrapAsyncRoute from '../util/wrapAsyncRoute';
-import {AUTH_TOKEN_COOKIE} from '../../universal/constants';
-import {getUserByAuthToken, serializeCurrentUser} from '../models/user';
-
-// The manifest is cached here if in production mode, since it won't change!!
-let manifest: any = null;
-async function loadManifest(): Promise<any> {
-  if (process.env.NODE_ENV === 'production' && manifest) {
-    return manifest;
-  }
-
-  const url = `${process.env.STATIC_URL}/manifest.json`;
-  const resp = await axios.get(url);
-  manifest = resp.data;
-  return manifest;
-}
-
-function scriptForChunk(manifest: any, name: string): string {
-  const assets = manifest.assetsByChunkName[name];
-  const filename = assets.find((asset: string) => asset.endsWith('.js'));
-  return `<script src="${process.env.STATIC_URL}/${filename}"></script>`;
-}
-
-function styleForChunk(manifest: any, name: string): string {
-  const assets = manifest.assetsByChunkName[name];
-  const filename = assets.find((asset: string) => asset.endsWith('.css'));
-  return `<link href="${process.env.STATIC_URL}/${filename}" rel="stylesheet" />`;
-}
+import renderSinglePageApp from '../ssr/render';
 
 export default function registerPagesEndpoints(router: Router) {
   router.get('*', wrapAsyncRoute(async (req, res) => {
-    const manifest = await loadManifest();
+    const html = await renderSinglePageApp(req, res);
 
-    const token = req.cookies[AUTH_TOKEN_COOKIE];
-
-    let currentUser = null;
-
-    if (token) {
-      const user = await getUserByAuthToken(token);
-
-      if (user) {
-        currentUser = await serializeCurrentUser(user);
-      }
-    }
-
-    const pageData = JSON.stringify({
-      currentUser,
-    });
-
-    res.send(`
-      <html>
-        <head>
-          <title>Jam Buds</title>
-          <script src="https://www.youtube.com/iframe_api"></script>
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          ${styleForChunk(manifest, 'app')}
-        </head>
-
-        <body>
-          <div class="react-root"></div>
-          <script>window.__PAGE_DATA__ = ${pageData}</script>
-          ${scriptForChunk(manifest, 'vendor')}
-          ${scriptForChunk(manifest, 'app')}
-        </body>
-      </html>
-    `);
+    res.send(html);
   }));
 }

--- a/src/server/ssr/Page.tsx
+++ b/src/server/ssr/Page.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+function scriptForChunk(manifest: any, name: string): React.ReactNode {
+  const assets = manifest.assetsByChunkName[name];
+  const filename = assets.find((asset: string) => asset.endsWith('.js'));
+  return (
+    <script src={`${process.env.STATIC_URL}/${filename}`}></script>
+  );
+}
+
+function styleForChunk(manifest: any, name: string): React.ReactNode {
+  const assets = manifest.assetsByChunkName[name];
+  const filename = assets.find((asset: string) => asset.endsWith('.css'));
+  return (
+    <link href={`${process.env.STATIC_URL}/${filename}`} rel="stylesheet" />
+  );
+}
+
+interface Props {
+  meta: {[s: string]: string},
+  manifest: any,
+  pageData: any,
+  innerHtml: string;
+}
+
+export default class Page extends React.Component<Props, {}> {
+  renderMeta() {
+    const {meta} = this.props;
+    const tags = _.map(meta, (val, key) =>
+      <meta key={key} name={key} content={val} />
+    );
+
+    return tags;
+  }
+
+  render() {
+    const {manifest, pageData, innerHtml} = this.props;
+
+    return (
+      <html>
+        <head>
+          <title>Jam Buds</title>
+          <script src="https://www.youtube.com/iframe_api"></script>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          {styleForChunk(manifest, 'app')}
+          {this.renderMeta()}
+        </head>
+
+        <body>
+          <div className="react-root" dangerouslySetInnerHTML={{
+            __html: innerHtml,
+          }} />
+          <script dangerouslySetInnerHTML={{
+            __html: `window.__PAGE_DATA__ = ${JSON.stringify(pageData)};`
+          }} />
+          {scriptForChunk(manifest, 'vendor')}
+          {scriptForChunk(manifest, 'app')}
+        </body>
+      </html>
+    );
+  }
+}

--- a/src/server/ssr/loadManifest.ts
+++ b/src/server/ssr/loadManifest.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+// The manifest is cached here if in production mode, since it won't change!!
+let manifest: any = null;
+export default async function loadManifest(): Promise<any> {
+  if (process.env.NODE_ENV === 'production' && manifest) {
+    return manifest;
+  }
+
+  const url = `${process.env.STATIC_URL}/manifest.json`;
+  const resp = await axios.get(url);
+  manifest = resp.data;
+  return manifest;
+}

--- a/src/server/ssr/render.tsx
+++ b/src/server/ssr/render.tsx
@@ -3,44 +3,66 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { match, RouterContext } from 'react-router'
 import {Provider} from 'mobx-react';
+import {serialize, deserialize} from 'serializr';
 
 import wrapAsyncRoute from '../util/wrapAsyncRoute';
 import {AUTH_TOKEN_COOKIE} from '../../universal/constants';
 import {CurrentUser} from '../../universal/resources';
-import {getUserByAuthToken, serializeCurrentUser} from '../models/user';
+import {User, getUserByAuthToken, serializeCurrentUser} from '../models/user';
 import {getPlaylistEntryById} from '../models/playlist';
 
 import Page from './Page';
 import loadManifest from './loadManifest';
 import {createRoutes, createStores} from '../../client/createApp';
 
+import axios from 'axios';
+axios.defaults.baseURL = `http://localhost:${process.env.PORT || 3000}`;
+
 export default async function renderApp(req: Request, res: Response, meta={}): Promise<string> {
   const manifest = await loadManifest();
 
   const token = req.cookies[AUTH_TOKEN_COOKIE];
 
-  let currentUser: CurrentUser | null = null;
+  let currentUser: User | null = null;
+  let serializedCurrentUser: CurrentUser | null = null;
 
   if (token) {
-    const user = await getUserByAuthToken(token);
-
-    if (user) {
-      currentUser = await serializeCurrentUser(user);
+    currentUser = await getUserByAuthToken(token);
+    if (currentUser) {
+      serializedCurrentUser = await serializeCurrentUser(currentUser);
     }
   }
 
   const stores = createStores();
-  if (currentUser) {
-    stores.userStore.loadUser(currentUser)
+  if (serializedCurrentUser) {
+    stores.userStore.loadUser(serializedCurrentUser)
   }
   const routes = createRoutes();
 
+  // const serializedData = JSON.stringify(stores);
+
   return new Promise<string>((resolve, reject) => {
-    match({ routes, location: req.url }, (error, redirectLocation, renderProps) => {
+    match({ routes, location: req.url }, async (error, redirectLocation, renderProps) => {
       if (error) {
         reject(error);
 
       } else if (renderProps) {
+        const fetchFns = renderProps.routes.map((route) => route.fetchData).filter((fn) => !!fn);
+
+        for (let fetchFn of fetchFns) {
+          // TODO:
+          // This could potentially lead to race conditions where the wrong token is used, I think
+          // this would be very bad, obviously.
+          axios.interceptors.request.use((config) => {
+            if (currentUser) {
+              config.headers['X-Auth-Token'] = currentUser.authToken;
+            }
+            return config;
+          });
+
+          await fetchFn(stores);
+        }
+
         const appHtml = ReactDOMServer.renderToString(
           <Provider {...stores}>
             <RouterContext {...renderProps} />
@@ -48,7 +70,8 @@ export default async function renderApp(req: Request, res: Response, meta={}): P
         );
 
         const html = ReactDOMServer.renderToStaticMarkup(
-          <Page pageData={{currentUser}} manifest={manifest} meta={{}} innerHtml={appHtml} />
+          <Page pageData={stores}
+            manifest={manifest} meta={{}} innerHtml={appHtml} />
         );
 
         resolve(html);

--- a/src/server/ssr/render.tsx
+++ b/src/server/ssr/render.tsx
@@ -1,0 +1,62 @@
+import {Router, Request, Response} from 'express';
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import { match, RouterContext } from 'react-router'
+import {Provider} from 'mobx-react';
+
+import wrapAsyncRoute from '../util/wrapAsyncRoute';
+import {AUTH_TOKEN_COOKIE} from '../../universal/constants';
+import {CurrentUser} from '../../universal/resources';
+import {getUserByAuthToken, serializeCurrentUser} from '../models/user';
+import {getPlaylistEntryById} from '../models/playlist';
+
+import Page from './Page';
+import loadManifest from './loadManifest';
+import {createRoutes, createStores} from '../../client/createApp';
+
+export default async function renderApp(req: Request, res: Response, meta={}): Promise<string> {
+  const manifest = await loadManifest();
+
+  const token = req.cookies[AUTH_TOKEN_COOKIE];
+
+  let currentUser: CurrentUser | null = null;
+
+  if (token) {
+    const user = await getUserByAuthToken(token);
+
+    if (user) {
+      currentUser = await serializeCurrentUser(user);
+    }
+  }
+
+  const stores = createStores();
+  if (currentUser) {
+    stores.userStore.loadUser(currentUser)
+  }
+  const routes = createRoutes();
+
+  return new Promise<string>((resolve, reject) => {
+    match({ routes, location: req.url }, (error, redirectLocation, renderProps) => {
+      if (error) {
+        reject(error);
+
+      } else if (renderProps) {
+        const appHtml = ReactDOMServer.renderToString(
+          <Provider {...stores}>
+            <RouterContext {...renderProps} />
+          </Provider>
+        );
+
+        const html = ReactDOMServer.renderToStaticMarkup(
+          <Page pageData={{currentUser}} manifest={manifest} meta={{}} innerHtml={appHtml} />
+        );
+
+        resolve(html);
+
+      } else {
+        res.status(404).send('page not found');
+        reject();
+      }
+    });
+  });
+}

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -8,6 +8,7 @@ module.exports = webpackMerge(config, {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: '"development"',
+        SERVER_URL: `"${process.env.SERVER_URL}"`,
       }
     }),
   ],

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -1,0 +1,70 @@
+var fs = require('fs');
+var webpack = require('webpack');
+
+var nodeModules = {};
+
+/*
+ * Prevent bundling of node modules
+ */
+fs.readdirSync('node_modules')
+  .filter(function(x) {
+    return ['.bin'].indexOf(x) === -1;
+  })
+  .forEach(function(mod) {
+    nodeModules[mod] = 'commonjs ' + mod;
+  });
+
+module.exports = {
+  entry: {
+    server: './src/server/entry.ts',
+  },
+
+  target: 'node',
+
+  output: {
+    path: './build/server',
+    filename: '[name].bundle.js'
+  },
+
+  resolve: {
+    extensions: ['', '.jsx', '.js', '.tsx', '.ts'],
+
+    alias: {
+      '__root': process.cwd(),
+    },
+  },
+
+  devtool: 'source-map',
+
+  externals: nodeModules,
+
+  plugins: [
+    new webpack.BannerPlugin('require("source-map-support").install();',
+                             { raw: true, entryOnly: false })
+  ],
+
+  ts: {
+    compilerOptions: {
+      noEmit: false,
+    },
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts',
+      },
+
+      {
+        test: /\.jpg$|\.png$/,
+        loader: 'file',
+      },
+
+      {
+        test: /\.svg$/,
+        loader: 'raw',
+      }
+    ]
+  }
+};


### PR DESCRIPTION
- [x] Gotta use cookie-based sessions instead of tokens so server can get current user
  - (still need to pass token in to requests to prevent CSRF though)
- [x] Render pages on the server via React
- [ ] Data fetching
- [ ] Add production server run-through-webpack script

Data fetching notes:

- Could run requests through `apiRequest` util, but use some configuration to do localhost queries instead of using external URL?
  - How does auth work in this case? just pass cookies along?
  - Should the API server just be totally separate?
- Rendering server needs to know when a page is "fully hydrated"
  - Create some kind of util that, on first render, finds <Loader> config?
- Could add `fetchData()` server-side-only calls to routing top level config? Frontend could also try to use these but idk how