### PR TITLE
App: Add mobile /add-song route for full-screen add song flow

### DIFF
--- a/app/src/components/AddSongButton.vue
+++ b/app/src/components/AddSongButton.vue
@@ -5,10 +5,18 @@
 </template>
 
 <script>
+import isMobile from '../util/isMobile';
+
 export default {
   methods: {
     handleClick() {
-      this.$store.dispatch('showAddSong');
+      if (isMobile()) {
+        this.$router.push('/add-song');
+      } else {
+        this.$store.dispatch('showAddSong');
+      }
+
+      this.$emit('click');
     },
   },
 };

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -2,41 +2,44 @@
   <div v-if="authenticated" :class="['sidebar', { '-open': open }]">
     <p>
       what up,
-      <router-link :to="`/users/${currentUserName}`">
+      <router-link :to="`/users/${currentUserName}`" @click="handleClick">
         {{ currentUserName }}
       </router-link>
     </p>
 
-    <add-song-button />
+    <add-song-button @click="handleClick" />
 
     <ul>
       <li>
-        <router-link to="/">
+        <router-link to="/" @click="handleClick">
           your feed
         </router-link>
       </li>
       <li>
-        <router-link :to="`/users/${currentUserName}`">
+        <router-link :to="`/users/${currentUserName}`" @click="handleClick">
           your playlist
         </router-link>
       </li>
       <li>
-        <router-link :to="`/users/${currentUserName}/liked`">
+        <router-link
+          :to="`/users/${currentUserName}/liked`"
+          @click="handleClick"
+        >
           your liked tracks
         </router-link>
       </li>
       <li>
-        <router-link to="/find-friends">
+        <router-link to="/find-friends" @click="handleClick">
           find twitter friends
         </router-link>
       </li>
       <li>
-        <router-link to="/settings">
+        <router-link to="/settings" @click="handleClick">
           your settings
         </router-link>
       </li>
       <li>
-        <router-link to="/about">
+        <router-link to="/about" @click="handleClick">
           about jam buds
         </router-link>
       </li>
@@ -74,6 +77,10 @@ export default {
       });
 
       document.location.href = '/';
+    },
+
+    handleClick() {
+      this.$store.commit('closeSidebar');
     },
   },
 };

--- a/app/src/components/new-song-modal/AddSongFlow.vue
+++ b/app/src/components/new-song-modal/AddSongFlow.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="add-song-screen">
+    <div :style="{ textAlign: 'center' }">
+      <h2>
+        share a jam!
+      </h2>
+    </div>
+
+    <!-- state router -->
+    <div :style="{ flex: '1 0 auto' }">
+      <initial-screen
+        v-if="state === INITIAL_STATE"
+        @selectedSong="handleSelectedSong"
+      />
+      <confirm-screen
+        v-if="state === CONFIRM_STATE"
+        :selected-song="selectedSong"
+        @finished="finished"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import InitialScreen from './InitialScreen.vue';
+import ConfirmScreen from './ConfirmScreen.vue';
+import isMobile from '../../util/isMobile';
+
+const INITIAL_STATE = 'initial';
+const CONFIRM_STATE = 'confirm';
+
+export default {
+  components: { InitialScreen, ConfirmScreen },
+
+  data() {
+    return {
+      state: INITIAL_STATE,
+      INITIAL_STATE,
+      CONFIRM_STATE,
+      selectedSong: null,
+    };
+  },
+
+  computed: mapState({
+    showAddSongModal: (state) => state.addSong.showModal,
+  }),
+
+  methods: {
+    handleOverlayClick() {
+      this.$store.dispatch('closeAddSong');
+      this.reset();
+    },
+    handleModalClick(evt) {
+      evt.stopPropagation();
+    },
+    handleSelectedSong(song) {
+      this.selectedSong = song;
+      this.state = CONFIRM_STATE;
+    },
+    finished() {
+      this.reset();
+      if (isMobile()) {
+        this.$router.push('/');
+      }
+    },
+    reset() {
+      this.state = INITIAL_STATE;
+      this.selectedSong = null;
+    },
+  },
+};
+</script>

--- a/app/src/components/new-song-modal/AddSongModal.vue
+++ b/app/src/components/new-song-modal/AddSongModal.vue
@@ -6,26 +6,7 @@
       @click="handleOverlayClick"
     >
       <div class="modal-content" @click="handleModalClick">
-        <div class="add-song-screen">
-          <div :style="{ textAlign: 'center' }">
-            <h2>
-              share a jam!
-            </h2>
-          </div>
-
-          <!-- state router -->
-          <div :style="{ flex: '1 0 auto' }">
-            <initial-screen
-              v-if="state === INITIAL_STATE"
-              @selectedSong="handleSelectedSong"
-            />
-            <confirm-screen
-              v-if="state === CONFIRM_STATE"
-              :selected-song="selectedSong"
-              @finished="reset"
-            />
-          </div>
-        </div>
+        <add-song-flow />
       </div>
     </div>
   </transition>
@@ -33,44 +14,14 @@
 
 <script>
 import { mapState } from 'vuex';
-import InitialScreen from './InitialScreen.vue';
-import ConfirmScreen from './ConfirmScreen.vue';
 
-const INITIAL_STATE = 'initial';
-const CONFIRM_STATE = 'confirm';
+import AddSongFlow from './AddSongFlow.vue';
 
 export default {
-  components: { InitialScreen, ConfirmScreen },
-
-  data() {
-    return {
-      state: INITIAL_STATE,
-      INITIAL_STATE,
-      CONFIRM_STATE,
-      selectedSong: null,
-    };
-  },
+  components: { AddSongFlow },
 
   computed: mapState({
     showAddSongModal: (state) => state.addSong.showModal,
   }),
-
-  methods: {
-    handleOverlayClick() {
-      this.$store.dispatch('closeAddSong');
-      this.reset();
-    },
-    handleModalClick(evt) {
-      evt.stopPropagation();
-    },
-    handleSelectedSong(song) {
-      this.selectedSong = song;
-      this.state = CONFIRM_STATE;
-    },
-    reset() {
-      this.state = INITIAL_STATE;
-      this.selectedSong = null;
-    },
-  },
 };
 </script>

--- a/app/src/pages/AddSongPage.vue
+++ b/app/src/pages/AddSongPage.vue
@@ -1,0 +1,29 @@
+<template>
+  <sidebar-wrapper v-slot="{ withSidebar }">
+    <main-wrapper
+      :with-sidebar="withSidebar"
+      :color-scheme="{ backgroundColor: 'skyblue', textColor: 'black' }"
+    >
+      <add-song-flow />
+    </main-wrapper>
+  </sidebar-wrapper>
+</template>
+
+<script>
+import SidebarWrapper from '../components/SidebarWrapper.vue';
+import MainWrapper from '../components/MainWrapper.vue';
+import AddSongFlow from '../components/new-song-modal/AddSongFlow.vue';
+import titleMixin from '../util/titleMixin';
+
+export default {
+  components: {
+    SidebarWrapper,
+    MainWrapper,
+    AddSongFlow,
+  },
+
+  mixins: [titleMixin],
+
+  title: 'Add Song',
+};
+</script>

--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -17,6 +17,8 @@ import UserFollowersPage from '../pages/users/UserFollowersPage.vue';
 import FindFriendsPage from '../pages/FindFriendsPage.vue';
 import SettingsPage from '../pages/SettingsPage.vue';
 
+import AddSongPage from '../pages/AddSongPage.vue';
+
 // import NotFoundPage from '../pages/NotFoundPage.vue';
 
 Vue.use(Router);
@@ -49,6 +51,7 @@ export default function createRouter() {
       },
       { path: '/find-friends', component: FindFriendsPage },
       { path: '/settings', component: SettingsPage },
+      { path: '/add-song', component: AddSongPage },
       // {path: '*', component: NotFoundPage},
     ],
   });

--- a/app/src/util/isMobile.js
+++ b/app/src/util/isMobile.js
@@ -1,0 +1,2 @@
+const isMobile = () => matchMedia('(max-width: 768px)');
+export default isMobile;


### PR DESCRIPTION
Don't love this because there's a few ugly bits (flash of "reset" content when navigating back to index after submit, for example). Might be better to redo this as a full-screen "modal"on mobile instead of giving it a special route.