### PR TITLE
Refactor playlist queries

### DIFF
--- a/api/src/models/__tests__/playlists.spec.ts
+++ b/api/src/models/__tests__/playlists.spec.ts
@@ -84,7 +84,7 @@ describe('models/playlists', () => {
       });
 
       const post = await getOwnPostForSongId({
-        songId: dupPost.songId,
+        songId: dupPost.songId!,
         userId: jeff.id,
       });
 
@@ -161,7 +161,8 @@ describe('models/playlists', () => {
 
       const items = await getLikesByUserId(user.id, { currentUserId: user.id });
       expect(items.length).toBe(1);
-      expect(items[0].song.id).toBe(id);
+      expect(items[0].type).toBe('song');
+      expect((items[0] as PlaylistSongItem).song.id).toBe(id);
     });
   });
 

--- a/api/src/models/__tests__/post.spec.ts
+++ b/api/src/models/__tests__/post.spec.ts
@@ -10,7 +10,7 @@ describe('models/post', () => {
       const entry = await postFactory({ userId: user.id });
       const post = await getOwnPostForSongId({
         userId: user.id,
-        songId: entry.songId,
+        songId: entry.songId!,
       });
 
       expect(post).toBeTruthy();
@@ -20,7 +20,7 @@ describe('models/post', () => {
       expect(
         await getOwnPostForSongId({
           userId: user.id,
-          songId: entry.songId,
+          songId: entry.songId!,
         })
       ).toBeFalsy();
     });

--- a/api/src/models/post.ts
+++ b/api/src/models/post.ts
@@ -3,11 +3,13 @@ import { date as dateType } from 'io-ts-types/lib/date';
 
 import { db } from '../db';
 import { Song } from '../resources';
-import { serializeSong, selectSongs } from './song';
+import { serializeSong, selectSongs, SongWithMetaModelV } from './song';
+import { findOneOrThrow } from './utils';
 
 export const PostModelV = t.type({
   id: t.number,
-  songId: t.number,
+  songId: t.union([t.number, t.null]),
+  mixtapeId: t.union([t.number, t.null]),
   userId: t.number,
   createdAt: dateType,
 });
@@ -28,7 +30,7 @@ export async function postSong(values: PostSongParams): Promise<Song> {
   const query = db!('songs')
     .select(selectSongs({ currentUserId: values.userId }))
     .where({ id: values.songId });
-  const [row] = await query;
+  const row = await findOneOrThrow(query, SongWithMetaModelV);
 
   return serializeSong(row);
 }

--- a/api/src/models/utils.ts
+++ b/api/src/models/utils.ts
@@ -2,7 +2,7 @@ import Knex from 'knex';
 import { snakecase } from 'stringcase';
 import * as t from 'io-ts';
 import { db } from '../db';
-import validateOrThrow from '../util/validateOrThrow';
+import validateOrThrow, { IoTypeC } from '../util/validateOrThrow';
 
 /**
  * Utility function that creates dot-separated select aliases for fields:
@@ -93,7 +93,15 @@ export function selectNamespacedModel(
   return db!.raw(namespacedAliases(tableName, keyName, tPropNames(model)));
 }
 
-export async function findOne<T extends t.TypeC<any>>(
+export function selectModelFields(
+  model: t.TypeC<any>,
+  tableName: string
+): string[] {
+  const fields = tPropNames(model);
+  return fields.map((field) => `${tableName}.${field}`);
+}
+
+export async function findOne<T extends IoTypeC>(
   query: Knex.QueryBuilder,
   model: T
 ): Promise<t.TypeOf<T> | null> {
@@ -109,7 +117,7 @@ export async function findOne<T extends t.TypeC<any>>(
   return row;
 }
 
-export async function findOneOrThrow<T extends t.TypeC<any>>(
+export async function findOneOrThrow<T extends IoTypeC>(
   query: Knex.QueryBuilder,
   model: T
 ): Promise<t.TypeOf<T>> {
@@ -122,7 +130,7 @@ export async function findOneOrThrow<T extends t.TypeC<any>>(
   return row;
 }
 
-export async function findMany<T extends t.TypeC<any>>(
+export async function findMany<T extends IoTypeC>(
   query: Knex.QueryBuilder,
   model: T
 ): Promise<t.TypeOf<T>[]> {

--- a/api/src/resources.ts
+++ b/api/src/resources.ts
@@ -38,7 +38,7 @@ export interface PlaylistSongItem {
   /**
    * A list of names of users you follow who posted the song.
    */
-  userNames: string[];
+  userNames?: string[];
 }
 
 export type PlaylistItem = PlaylistSongItem | PlaylistMixtapeItem;

--- a/api/src/routes/__tests__/likes.spec.ts
+++ b/api/src/routes/__tests__/likes.spec.ts
@@ -8,6 +8,7 @@ import { userFactory, songFactory } from '../../__tests__/factories';
 import { postSong } from '../../models/post';
 import { getLikesByUserId } from '../../models/playlists';
 import { createAuthTokenForUserId } from '../../models/authTokens';
+import { PlaylistSongItem } from '../../resources';
 
 const app = createApp();
 
@@ -40,8 +41,10 @@ describe('routes/likes', () => {
         currentUserId: jeff!.id,
       });
       expect(likes.length).toBe(1);
-      expect(likes[0].song.id).toBe(song.id);
-      expect(likes[0].song.isLiked).toBe(true);
+      const like = likes[0];
+      expect(like.type).toBe('song');
+      expect((like as PlaylistSongItem).song.id).toBe(song.id);
+      expect((like as PlaylistSongItem).song.isLiked).toBe(true);
     });
   });
 });

--- a/api/src/util/validateOrThrow.ts
+++ b/api/src/util/validateOrThrow.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 import { isLeft } from 'fp-ts/lib/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 
-type IoTypeC = t.TypeC<any> | t.IntersectionC<any>;
+export type IoTypeC = t.TypeC<any> | t.IntersectionC<any>;
 
 export default function validateOrThrow<T extends IoTypeC>(
   codec: T,


### PR DESCRIPTION
* Use whereIn() instead of joins to query for songs & mixtapes to simplify logic
* Move model validation out of serialize() path