### PR TITLE
Local spotify

### DIFF
--- a/app/src/pages/spotify-auth.vue
+++ b/app/src/pages/spotify-auth.vue
@@ -1,0 +1,77 @@
+<template>
+  <!-- TODO: loading spinner or something here ? -->
+  <div />
+</template>
+
+<script>
+import {
+  getAndClearSpotifyOauthState,
+  getAndClearSpotifyOauthRedirect,
+} from '~/util/localStorage';
+
+export default {
+  async mounted() {
+    const state = this.$route.query.state;
+    const code = this.$route.query.code;
+    const error = this.$route.query.error;
+
+    const savedState = getAndClearSpotifyOauthState();
+    const redirect = getAndClearSpotifyOauthRedirect() || '/';
+
+    const doRedirect = () => this.$router.replace(redirect);
+
+    if (state !== savedState) {
+      this.showError('Invalid Oauth state');
+      return doRedirect();
+    }
+
+    if (!redirect) {
+      this.showError('Invalid Oauth token');
+      return doRedirect();
+    }
+
+    if (error) {
+      this.showError('Oauth error');
+      return doRedirect();
+    }
+
+    let resp;
+    try {
+      resp = await this.redeemCode(code);
+    } catch (err) {
+      this.showError('Error redeeming code');
+      return doRedirect();
+    }
+    localStorage.setItem('spotifyRefreshToken', resp.refreshToken);
+    localStorage.setItem('spotifyAccessToken', resp.accessToken);
+    localStorage.setItem('spotifyExpiresIn', resp.expiresIn);
+    this.$store.dispatch('updateStreamingService', 'spotify');
+  },
+
+  async redeemCode(code) {
+    const resp = await this.$axios({
+      method: 'post',
+      url: '/api/spotify-token/swap',
+      data: { code },
+    });
+    return resp.data;
+  },
+
+  showError(error) {
+    // remove error from path to prevent re-triggering
+    this.$router.replace(this.$route.path);
+
+    if (error === 'nonPremium') {
+      this.$store.commit(
+        'showErrorModal',
+        "Error connecting Spotify: You must have a premium (paid) Spotify account to stream to it from Jam Buds.\n\nSorry, I don't make the rules :("
+      );
+    } else {
+      this.$store.commit(
+        'showErrorModal',
+        `Error connecting Spotify: ${error || '(unknown)'}`
+      );
+    }
+  },
+};
+</script>

--- a/app/src/util/localStorage.js
+++ b/app/src/util/localStorage.js
@@ -1,0 +1,32 @@
+const SPOTIFY_OAUTH_STATE_KEY = 'spotifyOauthState';
+const SPOTIFY_OAUTH_REDIRECT_KEY = 'spotifyOauthRedirect';
+
+// https://medium.com/@dazcyril/generating-cryptographic-random-state-in-javascript-in-the-browser-c538b3daae50
+function randomCryptoString() {
+  const validChars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let array = new Uint8Array(40);
+  window.crypto.getRandomValues(array);
+  array = array.map((x) => validChars.charCodeAt(x % validChars.length));
+  const randomState = String.fromCharCode.apply(null, array);
+  return randomState;
+}
+
+export function getAndClearSpotifyOauthState() {
+  const state = localStorage.getItem(SPOTIFY_OAUTH_STATE_KEY);
+  localStorage.removeItem(SPOTIFY_OAUTH_STATE_KEY);
+  return state;
+}
+export function getAndClearSpotifyOauthRedirect() {
+  const redirect = localStorage.getItem(SPOTIFY_OAUTH_REDIRECT_KEY);
+  localStorage.removeItem(SPOTIFY_OAUTH_REDIRECT_KEY);
+  return redirect;
+}
+export function createAndSetSpotifyOauthState() {
+  const state = randomCryptoString();
+  localStorage.setItem(SPOTIFY_OAUTH_STATE_KEY, state);
+  return state;
+}
+export function setSpotifyOauthRedirect(redirect) {
+  localStorage.setItem(SPOTIFY_OAUTH_REDIRECT_KEY, redirect);
+}

--- a/rhiannon/src/main/kotlin/club/jambuds/responses/RefreshSpotifyTokenResponse.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/responses/RefreshSpotifyTokenResponse.kt
@@ -1,0 +1,12 @@
+package club.jambuds.responses
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
+data class RefreshSpotifyTokenResponse(
+    @SerializedName("access_token")
+    @Expose val accessToken: String,
+    @SerializedName("expires_in")
+    @Expose val expiresIn: Int
+)

--- a/rhiannon/src/main/kotlin/club/jambuds/responses/SwapSpotifyTokenResponse.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/responses/SwapSpotifyTokenResponse.kt
@@ -1,0 +1,14 @@
+package club.jambuds.responses
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+// https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/
+data class SwapSpotifyTokenResponse(
+    @SerializedName("refresh_token")
+    @Expose val refreshToken: String,
+    @SerializedName("access_token")
+    @Expose val accessToken: String,
+    @SerializedName("expires_in")
+    @Expose val expiresIn: Int
+)


### PR DESCRIPTION
This adds some new endpoints to swap/refresh tokens for Spotify from the frontend, rather than go through server logic for the OAuth callback. However, I think we will want to have some additional server logic for web that differs from mobile, because it'd be best to store refresh tokens as HttpOnly cookies even if other logic is moved to the client.

TODO:

- [ ] Update Spotify connect code
- [ ] Reintroduce free-user error screen
- [ ] Remove old Spotify backend
- [ ] mobile: Encrypt Spotify access/refresh tokens at rest to prevent use outside of app (e.g. https://github.com/cjam/react-native-spotify-remote/blob/master/example-server/index.js#L21)