### PR TITLE
Add sign in code entry

### DIFF
--- a/app/src/components/sign-in-flow/SignInCodeEntry.vue
+++ b/app/src/components/sign-in-flow/SignInCodeEntry.vue
@@ -15,13 +15,12 @@
         placeholder="enter code..."
         aria-label="Code"
       />
-
       <button type="submit" class="submit" :disabled="requestInFlight">
         next
       </button>
     </form>
 
-    <p v-if="error">{{ error }}</p>
+    <field-error-display name="code" :errors="errors" />
 
     <p class="email-note">
       please allow up to 5 minutes for the email to arrive. due to strange
@@ -33,9 +32,10 @@
 
 <script>
 import SignInHeader from './SignInHeader.vue';
+import FieldErrorDisplay from '../FieldErrorDisplay.vue';
 
 export default {
-  components: { SignInHeader },
+  components: { SignInHeader, FieldErrorDisplay },
 
   props: ['sentEmail'],
 
@@ -43,7 +43,7 @@ export default {
     return {
       code: '',
       requestInFlight: false,
-      error: null,
+      errors: null,
     };
   },
 
@@ -62,8 +62,9 @@ export default {
       } catch (err) {
         this.requestInFlight = false;
 
-        if (err.response?.status === 400 && err.response?.data?.error) {
-          this.error = err.response.data.error;
+        if (err.response?.status === 400 && err.response?.data?.details) {
+          this.errors = err.response.data.details[0];
+          return;
         } else {
           this.$store.commit('showErrorModal');
           throw err;
@@ -83,6 +84,7 @@ export default {
 form {
   display: flex;
   width: 100%;
+  margin-bottom: $spacing-md;
 }
 
 input {

--- a/app/src/components/sign-in-flow/SignInCodeEntry.vue
+++ b/app/src/components/sign-in-flow/SignInCodeEntry.vue
@@ -1,0 +1,125 @@
+<template>
+  <div>
+    <sign-in-header>enter sign-in code</sign-in-header>
+
+    <p>
+      Check your inbox at
+      <strong>{{ sentEmail }}</strong>
+      for a 6-digit code.
+    </p>
+
+    <form @submit="handleSubmit">
+      <input
+        type="text"
+        v-model="code"
+        placeholder="enter code..."
+        aria-label="Code"
+      />
+
+      <button type="submit" class="submit" :disabled="requestInFlight">
+        next
+      </button>
+    </form>
+
+    <p v-if="error">{{ error }}</p>
+
+    <p class="email-note">
+      please allow up to 5 minutes for the email to arrive. due to strange
+      forces of computers outside of our control, sometimes our emails may go to
+      your "spam" folder, or, in Gmail, the "Promotions" tab.
+    </p>
+  </div>
+</template>
+
+<script>
+import SignInHeader from './SignInHeader.vue';
+
+export default {
+  components: { SignInHeader },
+
+  props: ['sentEmail'],
+
+  data() {
+    return {
+      code: '',
+      requestInFlight: false,
+      error: null,
+    };
+  },
+
+  methods: {
+    async handleSubmit(evt) {
+      evt.preventDefault();
+
+      let resp;
+      try {
+        this.requestInFlight = true;
+
+        resp = await this.$axios.post('validate-sign-in-code', {
+          email: this.sentEmail,
+          code: this.code,
+        });
+      } catch (err) {
+        this.requestInFlight = false;
+
+        if (err.response?.status === 400 && err.response?.data?.error) {
+          this.error = err.response.data.error;
+        } else {
+          this.$store.commit('showErrorModal');
+          throw err;
+        }
+      }
+
+      const redirect = resp.data.redirect;
+      document.location = redirect;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '~/assets/styles/mixins.scss';
+
+form {
+  display: flex;
+  width: 100%;
+}
+
+input {
+  min-width: 0;
+  flex-basis: 100%;
+  padding: 0px $spacing-2xs;
+  margin-right: $spacing-2xs;
+}
+
+.submit {
+  flex: 0 0 auto;
+  padding: 0 $spacing-xs;
+}
+
+input,
+.submit {
+  height: $spacing-3xl;
+}
+
+input {
+  @media (max-width: $breakpoint-small) {
+    font-size: $text-base;
+  }
+  @media (min-width: $breakpoint-small) {
+    font-size: $text-lg;
+  }
+}
+
+.submit {
+  font-size: $text-lg;
+  background: yellow;
+  color: black;
+  font-weight: bold;
+}
+
+.email-note {
+  font-size: $text-xs;
+  margin-top: $spacing-sm;
+}
+</style>

--- a/app/src/components/sign-in-flow/SignInFlow.vue
+++ b/app/src/components/sign-in-flow/SignInFlow.vue
@@ -12,6 +12,13 @@
       <div class="fade-screen" v-if="state === FORM_STEP" key="form">
         <sign-in-form @sentMail="handleSentMail" />
       </div>
+      <div
+        class="fade-screen"
+        v-if="state === CODE_ENTRY_STEP"
+        key="code-entry"
+      >
+        <sign-in-code-entry :sent-email="sentEmail" />
+      </div>
       <div class="fade-screen" v-if="state === SUCCESS_STEP" key="success">
         <sign-in-success :sent-email="sentEmail" />
       </div>
@@ -20,16 +27,18 @@
 </template>
 
 <script>
-import SignInForm from './SignInForm.vue';
 import SignInInitial from './SignInInitial.vue';
+import SignInForm from './SignInForm.vue';
+import SignInCodeEntry from './SignInCodeEntry.vue';
 import SignInSuccess from './SignInSuccess.vue';
 
 const INITIAL_STEP = 'initial';
 const FORM_STEP = 'form';
+const CODE_ENTRY_STEP = 'code-entry';
 const SUCCESS_STEP = 'success';
 
 export default {
-  components: { SignInInitial, SignInForm, SignInSuccess },
+  components: { SignInInitial, SignInForm, SignInCodeEntry, SignInSuccess },
 
   data() {
     return {
@@ -37,6 +46,7 @@ export default {
       sentEmail: null,
       INITIAL_STEP,
       FORM_STEP,
+      CODE_ENTRY_STEP,
       SUCCESS_STEP,
     };
   },
@@ -46,9 +56,9 @@ export default {
       this.state = FORM_STEP;
     },
 
-    handleSentMail(email) {
+    handleSentMail({ email, sentCode }) {
       this.sentEmail = email;
-      this.state = SUCCESS_STEP;
+      this.state = sentCode ? CODE_ENTRY_STEP : SUCCESS_STEP;
     },
   },
 };

--- a/rhiannon/src/main/kotlin/club/jambuds/dao/SignInTokenDao.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/dao/SignInTokenDao.kt
@@ -7,16 +7,22 @@ interface SignInTokenDao {
     @SqlUpdate(
         """
         INSERT INTO sign_in_tokens
-            (email, token)
+            (email, token, short_code)
         VALUES
-            (:email, :token)
+            (:email, :token, :shortCode)
     """
     )
-    fun createSignInToken(email: String, token: String)
+    fun createSignInToken(email: String, token: String, shortCode: String)
 
     @SqlQuery("SELECT email FROM sign_in_tokens WHERE token=:token")
     fun getEmailFromSignInToken(token: String): String?
 
+    @SqlQuery("SELECT token FROM sign_in_tokens WHERE email=:email AND short_code=:shortCode")
+    fun getSignInTokenFromEmailAndShortCode(email: String, shortCode: String): String?
+
     @SqlUpdate("DELETE FROM sign_in_tokens WHERE token=:token")
     fun deleteSignInToken(token: String)
+
+    @SqlUpdate("DELETE FROM sign_in_tokens WHERE email=:email")
+    fun deleteSignInTokensForUser(email: String)
 }

--- a/rhiannon/src/main/kotlin/club/jambuds/responses/ValidateSignInCodeResponse.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/responses/ValidateSignInCodeResponse.kt
@@ -1,0 +1,9 @@
+package club.jambuds.responses
+
+import com.google.gson.annotations.Expose
+
+data class ValidateSignInCodeResponse(
+    @Expose val signInToken: String,
+    @Expose val isRegistration: Boolean,
+    @Expose val redirect: String
+)

--- a/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
@@ -55,9 +55,14 @@ class AuthService(
         } else {
             // sign in
             val link = getSignInLink(token, dest)
+            val subject = if (sendCodeInsteadOfLink) {
+                "Your sign in code for jambuds.club"
+            } else {
+                "Your sign in link for jambuds.club"
+            }
             emailService.sendEmail(
                 email = email,
-                subject = "Your sign-in link for jambuds.club",
+                subject = subject,
                 templateName = "sign-in",
                 data = mapOf(
                     "name" to user.name,

--- a/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
@@ -89,7 +89,7 @@ class AuthService(
         referral: String?
     ): ValidateSignInCodeResponse {
         val token = signInTokenDao.getSignInTokenFromEmailAndShortCode(email, shortCode)
-            ?: throw BadRequestResponse("Invalid code.")
+            ?: throw FormValidationErrorResponse(listOf("code" to "Invalid code."))
         val user = userDao.getUserByEmail(email)
         val redirect = if (user == null) {
             getRegistrationLink(token, referral, null)

--- a/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/service/AuthService.kt
@@ -4,7 +4,9 @@ import club.jambuds.dao.AuthTokenDao
 import club.jambuds.dao.SignInTokenDao
 import club.jambuds.dao.UserDao
 import club.jambuds.responses.SendSignInTokenSkipAuthResponse
+import club.jambuds.responses.ValidateSignInCodeResponse
 import club.jambuds.util.FormValidationErrorResponse
+import club.jambuds.util.generateRandomNumberString
 import club.jambuds.util.generateRandomString
 import io.javalin.http.BadRequestResponse
 import io.sentry.Sentry
@@ -25,40 +27,44 @@ class AuthService(
     fun sendSignInToken(
         email: String,
         signUpReferral: String?,
-        dest: String?
+        dest: String?,
+        sendCodeInsteadOfLink: Boolean
     ): SendSignInTokenSkipAuthResponse? {
+        // ensure a user only has one active sign in token at a time
+        signInTokenDao.deleteSignInTokensForUser(email)
+
         val token = generateRandomString(24)
-        signInTokenDao.createSignInToken(email, token)
+        val shortCode = generateRandomNumberString(6)
+        signInTokenDao.createSignInToken(email, token, shortCode)
+
         val user = userDao.getUserByEmail(email)
-
-        val linkSuffix = if (dest != null) {
-            "&dest=$dest"
-        } else {
-            ""
-        }
-
         if (user == null) {
             // sign up
-            var link = "$appUrl/welcome/registration?t=$token" + linkSuffix
-
-            if (signUpReferral != null) {
-                link += "&referral=$signUpReferral"
-            }
+            val link = getRegistrationLink(token, signUpReferral, dest)
 
             emailService.sendEmail(
                 email = email,
                 subject = "Welcome to jambuds.club!",
                 templateName = "sign-up",
-                data = mapOf("registrationLink" to link)
+                data = mapOf(
+                    "sendCodeInsteadOfLink" to sendCodeInsteadOfLink,
+                    "registrationLink" to link,
+                    "shortCode" to shortCode
+                )
             )
         } else {
             // sign in
-            val link = "$appUrl/sign-in?t=$token" + linkSuffix
+            val link = getSignInLink(token, dest)
             emailService.sendEmail(
                 email = email,
                 subject = "Your sign-in link for jambuds.club",
                 templateName = "sign-in",
-                data = mapOf("name" to user.name, "signInLink" to link)
+                data = mapOf(
+                    "name" to user.name,
+                    "signInLink" to link,
+                    "sendCodeInsteadOfLink" to sendCodeInsteadOfLink,
+                    "shortCode" to shortCode
+                )
             )
         }
 
@@ -72,6 +78,27 @@ class AuthService(
         return null
     }
 
+    fun validateSignInCode(
+        email: String,
+        shortCode: String,
+        referral: String?
+    ): ValidateSignInCodeResponse {
+        val token = signInTokenDao.getSignInTokenFromEmailAndShortCode(email, shortCode)
+            ?: throw BadRequestResponse("Invalid code.")
+        val user = userDao.getUserByEmail(email)
+        val redirect = if (user == null) {
+            getRegistrationLink(token, referral, null)
+        } else {
+            getSignInLink(token, null)
+        }
+
+        return ValidateSignInCodeResponse(
+            signInToken = token,
+            isRegistration = user == null,
+            redirect = redirect
+        )
+    }
+
     fun signIn(token: String): String {
         val email = signInTokenDao.getEmailFromSignInToken(token)
             ?: throw BadRequestResponse("Invalid sign-in token")
@@ -83,6 +110,32 @@ class AuthService(
             )
 
         return createAuthTokenForUserId(user.id)
+    }
+
+    private fun getSignInLink(token: String, dest: String?): String {
+        val linkSuffix = if (dest != null) {
+            "&dest=$dest"
+        } else {
+            ""
+        }
+
+        return "$appUrl/sign-in?t=$token" + linkSuffix
+    }
+
+    private fun getRegistrationLink(token: String, referral: String?, dest: String?): String {
+        val linkSuffix = if (dest != null) {
+            "&dest=$dest"
+        } else {
+            ""
+        }
+
+        var link = "$appUrl/welcome/registration?t=$token" + linkSuffix
+
+        if (referral != null) {
+            link += "&referral=$referral"
+        }
+
+        return link
     }
 
     private fun createAuthTokenForUserId(id: Int): String {

--- a/rhiannon/src/main/kotlin/club/jambuds/util/generateRandomString.kt
+++ b/rhiannon/src/main/kotlin/club/jambuds/util/generateRandomString.kt
@@ -12,3 +12,14 @@ fun generateRandomString(len: Int): String {
     }
     return sb.toString()
 }
+
+// via https://stackoverflow.com/a/157202
+fun generateRandomNumberString(len: Int): String {
+    val ab = "0123456789"
+    val rnd = SecureRandom()
+    val sb = StringBuilder(len)
+    for (i in 0 until len) {
+        sb.append(ab[rnd.nextInt(ab.length)])
+    }
+    return sb.toString()
+}

--- a/rhiannon/src/main/resources/db/migration/V007__Sign_in_short_codes.sql
+++ b/rhiannon/src/main/resources/db/migration/V007__Sign_in_short_codes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sign_in_tokens ADD COLUMN "short_code" VARCHAR(6);
+CREATE INDEX sign_in_tokens_email_short_code_index ON public.sign_in_tokens USING btree (email, short_code);

--- a/rhiannon/src/main/resources/templates/emails/bigcode.html
+++ b/rhiannon/src/main/resources/templates/emails/bigcode.html
@@ -1,0 +1,10 @@
+{% macro bigcode(code='') %}
+<!-- Action -->
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+        <td align="center" style="font-size: 24px">
+            {{code}}
+        </td>
+    </tr>
+</table>
+{% endmacro %}

--- a/rhiannon/src/main/resources/templates/emails/sign-in.html
+++ b/rhiannon/src/main/resources/templates/emails/sign-in.html
@@ -1,5 +1,6 @@
 {% extends "base" %}
 {% import "cta" %}
+{% import "bigcode" %}
 
 {% block preheader %}
 Click here to sign in.
@@ -10,6 +11,11 @@ Click here to sign in.
 {% endblock %}
 
 {% block main %}
-<p>Welcome back! Just click the link below to sign back in:</p>
-{{ cta(ctaUrl=signInLink, ctaText='Log in!') }}
+{% if sendCodeInsteadOfLink == true %}
+    <p>Welcome back! Just copy-paste the code below into your browser and you'll be good to go:</p>
+    {{ bigcode(code = shortCode) }}
+{% else %}
+    <p>Welcome back! Just click the link below to sign back in:</p>
+    {{ cta(ctaUrl=signInLink, ctaText='Log in!') }}
+{% endif %}
 {% endblock %}

--- a/rhiannon/src/main/resources/templates/emails/sign-in.txt
+++ b/rhiannon/src/main/resources/templates/emails/sign-in.txt
@@ -1,5 +1,10 @@
 Hey {{name}}!
 
-Welcome back to Jam Buds! Just click this link to sign back in:
+Welcome back to Jam Buds! {% if sendCodeInsteadOfLink == true %}Just enter this code to continue:
+
+{{ shortCode }}
+{% else %}Just click this link to sign back in:
 
 {{signInLink}}
+{% endif %}
+

--- a/rhiannon/src/main/resources/templates/emails/sign-in.txt
+++ b/rhiannon/src/main/resources/templates/emails/sign-in.txt
@@ -1,6 +1,6 @@
 Hey {{name}}!
 
-Welcome back to Jam Buds! {% if sendCodeInsteadOfLink == true %}Just enter this code to continue:
+Welcome back to Jam Buds! {% if sendCodeInsteadOfLink == true %}Just enter this code in your browser to continue:
 
 {{ shortCode }}
 {% else %}Just click this link to sign back in:

--- a/rhiannon/src/main/resources/templates/emails/sign-up.html
+++ b/rhiannon/src/main/resources/templates/emails/sign-up.html
@@ -10,6 +10,11 @@ Click here to sign up.
 {% endblock %}
 
 {% block main %}
-<p>Welcome to Jam Buds! Just click the link below to get started:</p>
-{{ cta(ctaUrl=registrationLink, ctaText='Sign up now!') }}
+{% if sendCodeInsteadOfLink == true %}
+    <p>Welcome to Jam Buds! Just paste the following code back into your browser to continue:</p>
+    {{ cta(ctaUrl=registrationLink, ctaText='Sign up now!') }}
+{% else %}
+    <p>Welcome to Jam Buds! Just click the link below to get started:</p>
+    {{ cta(ctaUrl=registrationLink, ctaText='Sign up now!') }}
+{% endif %}
 {% endblock %}

--- a/rhiannon/src/main/resources/templates/emails/sign-up.txt
+++ b/rhiannon/src/main/resources/templates/emails/sign-up.txt
@@ -1,3 +1,7 @@
-Welcome to Jam Buds! Just click the link below to get started:
+Welcome to Jam Buds! {% if sendCodeInsteadOfLink == true %}Just enter this code in your browser to get started:
+
+{{ shortCode }}
+{% else %}Just click the link below to get started:
 
 {{registrationLink}}
+{% endif %}

--- a/rhiannon/src/test/kotlin/club/jambuds/web/AuthRoutesTest.kt
+++ b/rhiannon/src/test/kotlin/club/jambuds/web/AuthRoutesTest.kt
@@ -169,6 +169,23 @@ class AuthRoutesTest : AppTest() {
     }
 
     @Test
+    fun `POST validate-sign-in-code - returns 400 for invalid code`() {
+        val user = TestDataFactories.createUser(txn, "jeff", true)
+
+        // with no token
+        var body = JSONObject(mapOf("email" to user.email, "code" to "123456"))
+        var resp = Unirest.post("$appUrl/validate-sign-in-code").body(body).asString()
+        assertEquals(400, resp.status)
+
+        // with invalid token
+        createSignInToken(user.email)
+
+        body = JSONObject(mapOf("email" to user.email, "code" to "123456"))
+        resp = Unirest.post("$appUrl/validate-sign-in-code").body(body).asString()
+        assertEquals(400, resp.status)
+    }
+
+    @Test
     fun `POST validate-sign-in-code - returns redirect url with sign-in route and sign in token for returning user`() {
         val user = TestDataFactories.createUser(txn, "jeff", true)
         createSignInToken(user.email)

--- a/rhiannon/src/test/kotlin/club/jambuds/web/AuthRoutesTest.kt
+++ b/rhiannon/src/test/kotlin/club/jambuds/web/AuthRoutesTest.kt
@@ -143,7 +143,7 @@ class AuthRoutesTest : AppTest() {
             fromEmail = any(),
             fromName = any(),
             toEmail = eq(email),
-            subject = argForWhich { contains("sign-in") },
+            subject = argForWhich { contains("sign in") },
             textContent = check {
                 assertTrue(it.contains("Welcome back"))
                 assertTrue(it.contains(url))


### PR DESCRIPTION
Add sign in code entry for use on platforms that don't work well with magic links - basically, anything that won't open links from emails in the same shared cookie context as regular web browser. Currently this is scoped to iOS and Android.

Hopefully this becomes less necessary once native apps are launched, but this feels like a reasonable workaround for now. We may even eventually want to use this for desktop as well, to avoid the issue of users e.g. clicking the link on their phone and expecting it to approve their login in the browser (as described in https://uxdesign.cc/user-friendly-magic-links-e39023ec3e2).

### Todo

- [x] Unit tests for validation endpoint
- [x] New HTML email templates for code logins
- [x] Update email subject lines
- [ ] Improve design of code input
- [ ] Add feature tests for code-based login
